### PR TITLE
Iter24: support trusted subnet

### DIFF
--- a/cmd/agent/app.go
+++ b/cmd/agent/app.go
@@ -155,6 +155,7 @@ func (m *agent) send(ctx context.Context, wg *sync.WaitGroup, jobs <-chan []mode
 
 		var resp *resty.Response
 		request := m.Client.R().
+			SetHeader(model.XRealIPHeader, GetLocalIP()).
 			SetHeader("Content-Encoding", "gzip").
 			SetBody(buf.Bytes())
 		if m.HashService != nil {

--- a/cmd/agent/config.go
+++ b/cmd/agent/config.go
@@ -9,10 +9,10 @@ import (
 )
 
 const (
-	defaultServerURL = "localhost:8080"
-	defaultPollInterval = 2
+	defaultServerURL      = "localhost:8080"
+	defaultPollInterval   = 2
 	defaultReportInterval = 10
-	defaultRateLimit = 3
+	defaultRateLimit      = 3
 )
 
 func parseConfig() (*model.AgentConfig, error) {
@@ -29,10 +29,10 @@ func parseConfig() (*model.AgentConfig, error) {
 	flag.Parse()
 
 	cfg := model.AgentConfig{
-		ServerURL: defaultServerURL,
-		PollInterval: defaultPollInterval,
+		ServerURL:      defaultServerURL,
+		PollInterval:   defaultPollInterval,
 		ReportInterval: defaultReportInterval,
-		RateLimit: defaultRateLimit,
+		RateLimit:      defaultRateLimit,
 	}
 	if configPath != "" {
 		err := model.ParseFileConfig(configPath, &cfg)

--- a/cmd/agent/config_test.go
+++ b/cmd/agent/config_test.go
@@ -12,7 +12,7 @@ import (
 func TestAgentConfig_Parse(t *testing.T) {
 	tests := []struct {
 		name          string
-		giveArgs 	  []string
+		giveArgs      []string
 		wantAddr      string
 		wantPoll      int
 		wantReport    int
@@ -31,7 +31,7 @@ func TestAgentConfig_Parse(t *testing.T) {
 		},
 		{
 			name:          "WithArgs",
-			giveArgs: 	   []string{"-a", "localhost:8081", "-p", "4", "-r", "20", "-k", "key", "-l", "5", "-crypto-key", "cryptoKey"},
+			giveArgs:      []string{"-a", "localhost:8081", "-p", "4", "-r", "20", "-k", "key", "-l", "5", "-crypto-key", "cryptoKey"},
 			wantAddr:      "localhost:8081",
 			wantPoll:      4,
 			wantReport:    20,

--- a/cmd/agent/ipaddr.go
+++ b/cmd/agent/ipaddr.go
@@ -1,0 +1,19 @@
+package main
+
+import "net"
+
+func GetLocalIP() string {
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		return ""
+	}
+	for _, address := range addrs {
+		// check the address type and if it is not a loopback the display it
+		if ipnet, ok := address.(*net.IPNet); ok && !ipnet.IP.IsLoopback() {
+			if ipnet.IP.To4() != nil {
+				return ipnet.IP.String()
+			}
+		}
+	}
+	return ""
+}

--- a/cmd/agent/ipaddr_test.go
+++ b/cmd/agent/ipaddr_test.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetLocalIP(t *testing.T) {
+	localIP := GetLocalIP()
+	fmt.Printf("Local IP: %s", localIP)
+	assert.NotEqual(t, "127.0.0.1", localIP)
+}

--- a/cmd/server/config.go
+++ b/cmd/server/config.go
@@ -9,17 +9,17 @@ import (
 )
 
 const (
-	defaultAddress = "localhost:8080"
+	defaultAddress       = "localhost:8080"
 	defaultStoreInterval = 300
-	defaultFilePath = "/tmp/metrics-db.json"
-	defaultRestore = true
+	defaultFilePath      = "/tmp/metrics-db.json"
+	defaultRestore       = true
 )
 
 func parseConfig() (*model.ServerConfig, error) {
 	var configPath string
 	flag.StringVar(&configPath, "config", "", "Path to config file")
 	flag.StringVar(&configPath, "c", "", "Path to config file (shorthand)")
-	
+
 	addr := flag.String("a", defaultAddress, "Net address host:port")
 	storeInterval := flag.Int("i", defaultStoreInterval, "Store interval in seconds")
 	filePath := flag.String("f", defaultFilePath, "Filepath where metrics will be saved")
@@ -27,13 +27,14 @@ func parseConfig() (*model.ServerConfig, error) {
 	dsn := flag.String("d", "", "Database connection string")
 	key := flag.String("k", "", "Key that will be used to calculate hash")
 	cryptoKey := flag.String("crypto-key", "", "Private key that will be used to decrypt the request payload")
+	trustedSubnet := flag.String("t", "", "Whitelisted subnet in CIDR format")
 	flag.Parse()
 
 	cfg := model.ServerConfig{
-		Address: defaultAddress,
+		Address:       defaultAddress,
 		StoreInterval: defaultStoreInterval,
-		FilePath: defaultFilePath,
-		Restore: defaultRestore,
+		FilePath:      defaultFilePath,
+		Restore:       defaultRestore,
 	}
 	if configPath != "" {
 		err := model.ParseFileConfig(configPath, &cfg)
@@ -61,6 +62,9 @@ func parseConfig() (*model.ServerConfig, error) {
 	}
 	if *cryptoKey != "" {
 		cfg.CryptoKey = *cryptoKey
+	}
+	if *trustedSubnet != "" {
+		cfg.TrustedSubnet = *trustedSubnet
 	}
 	if err := env.Parse(&cfg); err != nil {
 		return nil, err

--- a/cmd/server/config_test.go
+++ b/cmd/server/config_test.go
@@ -20,6 +20,7 @@ func TestServerConfig_Parse(t *testing.T) {
 		wantKey           string
 		wantDSN           string
 		wantCryptoKey     string
+		wantTrustedSubnet string
 	}{
 		{
 			name:              "Default",
@@ -30,10 +31,12 @@ func TestServerConfig_Parse(t *testing.T) {
 			wantKey:           "",
 			wantDSN:           "",
 			wantCryptoKey:     "",
+			wantTrustedSubnet: "",
 		},
 		{
-			name:              "WithArgs",
-			giveArgs:          []string{"-a", "localhost:8081", "-i", "400", "-f", "filepath", "-d", "dsn", "-k", "key", "-crypto-key", "cryptoKey"},
+			name: "WithArgs",
+			giveArgs: []string{"-a", "localhost:8081", "-i", "400", "-f", "filepath", "-d", "dsn",
+				"-k", "key", "-crypto-key", "cryptoKey", "-t", "192.168.2.0/24"},
 			wantAddr:          "localhost:8081",
 			wantFilepath:      "filepath",
 			wantStoreInterval: 400,
@@ -41,6 +44,7 @@ func TestServerConfig_Parse(t *testing.T) {
 			wantKey:           "key",
 			wantDSN:           "dsn",
 			wantCryptoKey:     "cryptoKey",
+			wantTrustedSubnet: "192.168.2.0/24",
 		},
 	}
 
@@ -60,6 +64,7 @@ func TestServerConfig_Parse(t *testing.T) {
 			assert.Equal(t, tt.wantKey, cfg.Key)
 			assert.Equal(t, tt.wantDSN, cfg.DatabaseDSN)
 			assert.Equal(t, tt.wantCryptoKey, cfg.CryptoKey)
+			assert.Equal(t, tt.wantTrustedSubnet, cfg.TrustedSubnet)
 		})
 	}
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -59,6 +59,9 @@ func main() {
 	router := gin.New()
 	router.Use(gin.Recovery())
 	router.Use(middleware.LoggerWithZap(logger.Log()))
+	if serverConfig.TrustedSubnet != "" {
+		router.Use(middleware.CheckIPAddr(serverConfig.TrustedSubnet))
+	}
 	if serverConfig.Key != "" {
 		router.Use(middleware.VerifyHash(service.NewHashService(serverConfig.Key)))
 	}

--- a/internal/middleware/ipaddr.go
+++ b/internal/middleware/ipaddr.go
@@ -1,0 +1,37 @@
+package middleware
+
+import (
+	"net"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/itallix/go-metrics/internal/logger"
+	"github.com/itallix/go-metrics/internal/model"
+)
+
+func CheckIPAddr(trustedSubnet string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		clientIPStr := c.GetHeader(model.XRealIPHeader)
+		clientIP := net.ParseIP(clientIPStr)
+		if clientIP == nil {
+			logger.Log().Errorf("Error converting client IP addr from: %s", clientIPStr)
+			c.AbortWithStatus(http.StatusForbidden)
+			return
+		}
+
+		_, ipNet, err := net.ParseCIDR(trustedSubnet)
+		if err != nil {
+			logger.Log().Errorf("Error parsing CIDR address: %v", err)
+			c.AbortWithStatus(http.StatusForbidden)
+			return
+		}
+
+		if !ipNet.Contains(clientIP) {
+			c.AbortWithStatus(http.StatusForbidden)
+			return
+		}
+
+		c.Next()
+	}
+}

--- a/internal/middleware/ipaddr_test.go
+++ b/internal/middleware/ipaddr_test.go
@@ -1,0 +1,52 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/itallix/go-metrics/internal/model"
+)
+
+func TestCheckIPAddrMiddleware(t *testing.T) {
+	tests := []struct {
+		name       string
+		givenIP    string
+		wantStatus int
+	}{
+		{
+			name:       "OK",
+			givenIP:    "192.168.2.60",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "OK",
+			givenIP:    "192.168.1.60",
+			wantStatus: http.StatusForbidden,
+		},
+	}
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(CheckIPAddr("192.168.2.0/24"))
+
+	r.GET("/test", func(c *gin.Context) {
+		c.String(200, "Hello World")
+	})
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/test", strings.NewReader("Body hey"))
+			req.Header.Set(model.XRealIPHeader, tt.givenIP)
+			w := httptest.NewRecorder()
+
+			r.ServeHTTP(w, req)
+
+			assert.Equal(t, tt.wantStatus, w.Code)
+		})
+	}
+}

--- a/internal/model/config.go
+++ b/internal/model/config.go
@@ -18,6 +18,7 @@ type ServerConfig struct {
 	DatabaseDSN   string `env:"DATABASE_DSN" json:"database_dsn"`     // DB connection string, example: postgresql://username:password@hostname:port/database_name.
 	Key           string `env:"KEY" json:"hash_secret"`               // Secret for a hash function.
 	CryptoKey     string `env:"CRYPTO_KEY" json:"crypto_key"`         // Private key used to decrypt request payload.
+	TrustedSubnet string `env:"TRUSTED_SUBNET" json:"trusted_subnet"` // Whitelisted CIDR subnet addr.
 }
 
 // AgentConfig describes customization settings for the agent.

--- a/internal/model/config_test.go
+++ b/internal/model/config_test.go
@@ -34,6 +34,7 @@ func TestParseServerConfig(t *testing.T) {
 		StoreInterval: 1,
 		FilePath:      "/path/to/file.db",
 		CryptoKey:     "/path/to/key.pem",
+		TrustedSubnet: "192.168.2.0/24",
 	}
 
 	var cfg ServerConfig
@@ -47,4 +48,5 @@ func TestParseServerConfig(t *testing.T) {
 	assert.Equal(t, wantConfig.Key, cfg.Key)
 	assert.Equal(t, wantConfig.DatabaseDSN, cfg.DatabaseDSN)
 	assert.Equal(t, wantConfig.CryptoKey, cfg.CryptoKey)
+	assert.Equal(t, wantConfig.TrustedSubnet, cfg.TrustedSubnet)
 }

--- a/internal/model/constant.go
+++ b/internal/model/constant.go
@@ -1,3 +1,4 @@
 package model
 
 const HashSha256Header = "HashSHA256"
+const XRealIPHeader = "X-Real-IP"

--- a/test_data/serverConfig.json
+++ b/test_data/serverConfig.json
@@ -4,5 +4,6 @@
     "store_interval": "1s",
     "store_file": "/path/to/file.db",
     "database_dsn": "",
-    "crypto_key": "/path/to/key.pem"
+    "crypto_key": "/path/to/key.pem",
+    "trusted_subnet": "192.168.2.0/24"
 }


### PR DESCRIPTION
- [x] Agent: send IP address in X-Real-IP header
- [x] Server: add support for trusted network option